### PR TITLE
add 'go mod vendor' into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN git init && \
 # Download dependiencies before copying the source so they will be cached
 COPY go.mod go.sum ./
 RUN go mod download
+RUN go mod vendor
 
 
 ###############################################################################


### PR DESCRIPTION
#### Motivation
For openshift-ci, `go mod vendor` command is needed in Dockerfile.

This command does not impact to modelmesh-runtime-adapter image. It just helps to copy packages into the repository.