### PR TITLE
[RHOAIENG-16047] - Resolve CVE for odh-modelmesh-runtime-adapter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,8 @@ tensorflow-io-gcs-filesystem==0.34.0
 termcolor==2.4.0
 typing-extensions==4.5.0
 urllib3==2.2.2
-werkzeug==3.0.4
+werkzeug==3.0.6
 wheel==0.44.0
 wrapt==1.16.0
 zipp==3.20.1
+


### PR DESCRIPTION
chore:	This commit will fix [GHSA-q34m-jh98-gwm2](https://github.com/advisories/GHSA-q34m-jh98-gwm2).
	Updates werkzeug from 3.0.4 to 3.0.6

#### Motivation

#### Modifications

#### Result
