### PR TITLE
adding brettmthompson as approver and reviewer in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+  - brettmthompson
   - danielezonca
   - hdefazio
   - israel-hdez
@@ -10,6 +11,7 @@ approvers:
   - terrytangyuan
   - VedantMahabaleshwarkar
 reviewers:
+  - brettmthompson
   - hdefazio
   - israel-hdez
   - Jooho


### PR DESCRIPTION
#### Motivation
user brettmthompson requires approver and reviewer permissions in this repo

#### Modifications
adding brettmthompson to the approver and reviewer list in the OWNERS file

#### Result
user brettmthompson will be listed as a reviewer and will have access to approve PRs in this repo