### PR TITLE
RHOAIENG-19620: Bump Go to 1.23.6 (#101)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ###############################################################################
 # Stage 1: Create the developer image for the BUILDPLATFORM only
 ###############################################################################
-ARG GOLANG_VERSION=1.22
+ARG GOLANG_VERSION=1.23
 ARG BUILD_BASE=develop
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION AS develop
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/modelmesh-runtime-adapter
 
-go 1.22.9
+go 1.23.6
 
 require (
 	cloud.google.com/go/storage v1.28.1


### PR DESCRIPTION
Fix `CVE-2025-22866`.

CP of https://github.com/kserve/modelmesh-runtime-adapter/commit/b2caec295d9053d6915224a38a3705042e100c31