### PR TITLE
Add Konflux ODH tag bump automation to our existing release workflow.

### DIFF
--- a/.github/workflows/create-tag-release.yml
+++ b/.github/workflows/create-tag-release.yml
@@ -4,8 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: "Tag name for the new release"
+        description: "New release tag (e.g., odh-v2.35)"
         required: true
+        type: string
+      next_odh_tag:
+        description: "Next development tag (e.g., odh-v2.36)"
+        required: true
+        type: string
+    #
+    # Note: This workflow assumes the release tag and image tags are in sync.
+    #       'tag_name' is used to create the release and as the value to find in files.
+    #       'next_odh_tag' provides the new value to set.
+    #
 
 permissions:
   contents: write
@@ -80,3 +90,42 @@ jobs:
           files: bin/*
           generate_release_notes: true
           name: ${{ github.event.inputs.tag_name }}
+
+  bump-odh-tag:
+    name: Bump ODH Tag for Next Release
+    runs-on: ubuntu-latest
+    needs: changelog
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Update odh-modelmesh-runtime-adapter-push.yaml with next ODH tag
+        run: |
+          CURRENT_TAG="${{ github.event.inputs.tag_name }}"
+          NEXT_TAG="${{ github.event.inputs.next_odh_tag }}"
+          
+          echo "Updating ODH tag from $CURRENT_TAG to $NEXT_TAG..."
+          
+          # Using sed to replace the current ODH tag with the next one,
+          # anchored to the image name to prevent over-matching.
+          sed -i "s|modelmesh-runtime-adapter:${CURRENT_TAG}|modelmesh-runtime-adapter:${NEXT_TAG}|g" .tekton/odh-modelmesh-runtime-adapter-push.yaml
+
+          echo "Update complete."
+          
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add .tekton/odh-modelmesh-runtime-adapter-push.yaml
+          
+          # Check for changes before committing
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No changes to commit. Exiting."
+          else
+            git commit -m "chore(konflux): Bump ODH release tag to ${{ github.event.inputs.next_odh_tag }}"
+            git push
+          fi  


### PR DESCRIPTION
#### Motivation
This PR automates the process of updating the ODH release tag in the `modelmesh-runtime-adapter` repository's `Tekton` build file. This is a crucial step for preparing the codebase for the next development sprint immediately after a new release is cut, preventing manual and error-prone updates.

#### Modifications
* Added a new job named `bump-odh-tag` to the `create-release.yaml` workflow.
* Updated the `workflow_dispatch` trigger to include a `next_odh_tag` input.
* The new job uses a `sed` command anchored to the `modelmesh-runtime-adapter:` image prefix to precisely update the tag from `odh-v2.35` to `odh-v2.36` in the `.tekton/odh-modelmesh-runtime-adapter-push.yaml` file.

#### Result
The automation successfully updated the image tag in the specified `Tekton` file. A test run using `odh-v2.35` as the current tag and `odh-v2.36` as the next tag successfully modified the `value` field from `quay.io/opendatahub/modelmesh-runtime-adapter:odh-v2.35` to `quay.io/opendatahub/modelmesh-runtime-adapter:odh-v2.36` and created a new release as intended. The changes were then reverted and squashed for a clean PR.