### PR TITLE
[RHOAIENG-41181] - CVE-2025-12638: Path Traversal Vulnerability in keras

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ grpcio==1.73.0
 # for arm yet.
 h5py==3.12.0
 idna==3.10
-keras==3.11.3
+keras==3.12
 libclang==18.1.1
 Markdown==3.8
 markdown-it-py==3.0.0


### PR DESCRIPTION
chore:	Fix CVE-2025-12638 rhoai/odh-modelmesh-runtime-adapter-rhel9: Path Traversal Vulnerability in keras

#### Motivation

#### Modifications

#### Result
