### PR TITLE
[2.x] chore(deps): Bump urllib3 from 2.4.0 to 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,6 @@ tensorflow==2.19.0
 tensorflow-io-gcs-filesystem==0.34.0
 termcolor==3.1.0
 typing_extensions==4.14.0
-urllib3==2.4.0
+urllib3==2.6.0
 Werkzeug==3.1.3
 wrapt==1.17.2


### PR DESCRIPTION
See https://github.com/opendatahub-io/modelmesh-runtime-adapter/pull/133