### PR TITLE
[RHOAIENG-52069] CVE-2025-69534: Bump Markdown to 3.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ h5py==3.12.0
 idna==3.10
 keras==3.13.2
 libclang==18.1.1
-Markdown==3.8
+Markdown==3.8.1
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2


### PR DESCRIPTION
## Summary

- Bumps `Markdown` from 3.8 to 3.8.1 to fix CVE-2025-69534
- Python-Markdown 3.8 contains a vulnerability where malformed HTML-like sequences cause `html.parser.HTMLParser` to raise an unhandled `AssertionError`, enabling remote DoS

## JIRA

- [RHOAIENG-52069](https://issues.redhat.com/browse/RHOAIENG-52069) - odh-modelmesh-runtime-adapter-rhel9 [rhoai-2.25]
- [RHOAIENG-52065](https://issues.redhat.com/browse/RHOAIENG-52065) - odh-modelmesh-runtime-adapter-rhel9 [rhoai-2.22] (needs separate downstream PR)

## Notes

- `Markdown` is a transitive dependency of `tensorboard` (via `tensorflow`). It is not directly imported by any code in this repo.
- Existing dependabot PRs target `main` ([odh #144](https://github.com/opendatahub-io/modelmesh-runtime-adapter/pull/144), [downstream #1700](https://github.com/red-hat-data-services/modelmesh-runtime-adapter/pull/1700)) but not `stable-2.x`.

## Test plan

- [x] Docker runtime image builds successfully with `Markdown==3.8.1`

Made with [Cursor](https://cursor.com)