### PR TITLE
[CVE-2026-1462]-chore: bump keras to 3.14.0 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ grpcio==1.73.0
 # for arm yet.
 h5py==3.12.0
 idna==3.10
-keras==3.13.2
+keras==3.14.0
 libclang==18.1.1
 Markdown==3.8.1
 markdown-it-py==3.0.0


### PR DESCRIPTION
chore: bump keras to 3.14.0 to pick up the CVE-2026-1462 fix
