### PR TITLE
CVE-2026-44432: urllib3 DoS due to excessive HTTP response decompression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,8 @@ tensorflow==2.19.0
 tensorflow-io-gcs-filesystem==0.34.0
 termcolor==3.1.0
 typing_extensions==4.14.0
-urllib3==2.6.3
+# CVE-2026-44432: Denial of Service due to excessive HTTP response decompression fixed in urllib3 2.7.0
+urllib3==2.7.0
 Werkzeug==3.1.3
 wheel==0.46.2
 wrapt==1.17.2


### PR DESCRIPTION
chore: Bump urllib3 from 2.6.0 to 2.7.0 to fix CVE-2026-44432 denial of service vulnerability in HTTP response decompression streaming API.

#### Motivation

#### Modifications

#### Result


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a network library to address a security-related denial-of-service issue, improving stability.
* **Maintenance**
  * Refreshed the Go toolchain and dependencies used by the project.
  * Updated the container build environment (newer base, Python version, and build tooling) to streamline builds.
* **New Features**
  * Enhanced the release workflow with an additional tag bump step to keep related tags in sync.
* **Documentation**
  * Added guidance for handling `requirements.txt` with the Konflux prefetch build system.
* **Chores**
  * Updated the linting hook version for consistent checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->